### PR TITLE
Reset backToLobby timer when going back to lobby

### DIFF
--- a/Server/SanicballServerLib/Server.cs
+++ b/Server/SanicballServerLib/Server.cs
@@ -961,6 +961,7 @@ namespace SanicballServerLib
 
                 playersStillRacing.Clear();
                 clientsWantingToReturn.Clear();
+                backToLobbyTimer.Reset();
 
                 //Stage rotation
                 switch (matchSettings.StageRotationMode)


### PR DESCRIPTION
Fixes rare occurrence of going back to the lobby at the start of a race
if you vote to go back to the lobby during the 15 second timer
